### PR TITLE
Fix misc issues

### DIFF
--- a/src/TootleLib/RayTracer/JRT/JRTCamera.cpp
+++ b/src/TootleLib/RayTracer/JRT/JRTCamera.cpp
@@ -99,7 +99,7 @@ void JRTPerspectiveCamera::ProjectPoint(const Vec3f& pt, float* s, float* t) con
     splat.x /= m_plane_width;
     splat.y /= -m_plane_width;
 
-    if (abs(splat.x) > 0.5 || abs(splat.y) > 0.5)
+    if (std::abs(splat.x) > 0.5 || std::abs(splat.y) > 0.5)
     {
         *s = -1;
         *t = -1;

--- a/src/TootleLib/RayTracer/JRT/JRTHeuristicKDTreeBuilder.cpp
+++ b/src/TootleLib/RayTracer/JRT/JRTHeuristicKDTreeBuilder.cpp
@@ -28,7 +28,7 @@ bool SplitLess(const Split& s1, const Split& s2)
     // if we have a degenerate bounding box, force splits to be ordered min, then max
     if (s1.value == s2.value && s1.nTriBB == s2.nTriBB)
     {
-        return (!s1.bMaxSplit);
+        return (!s1.bMaxSplit && s2.bMaxSplit);
     }
     else
     {

--- a/src/TootleLib/RayTracer/JRT/JRTPPMImage.cpp
+++ b/src/TootleLib/RayTracer/JRT/JRTPPMImage.cpp
@@ -260,7 +260,7 @@ bool JRTPPMImage::LoadFile(const char* filename)
 
     // verify that we got all the header information we needed
     // if we're EOF, it means we did not
-    if (feof(fp) && !got_width || !got_height || !got_maxval)
+    if (feof(fp) && (!got_width || !got_height || !got_maxval))
     {
         fclose(fp);
         return false;

--- a/src/TootleLib/TootlePCH.h
+++ b/src/TootleLib/TootlePCH.h
@@ -25,6 +25,7 @@
     #include <cstdio>
     #include <cstdlib>
     #include <cstring>
+    #include <cmath>
     #include <functional>
     #include <list>
     #include <map>
@@ -32,7 +33,6 @@
     #include <set>
     #include <string>
     #include <vector>
-
 #else
 
     #include <stdio.h>


### PR DESCRIPTION
I ran into a few issues while experimenting with Tootle a while back so I figured I'd submit fixes back. 
1. SplitLess() in JRTHeuristicKDTreeBuilder.cpp could cause crashing with duplicate entries due to assumption that if s1 was a min split s2 would be a max split. Fix was to enforce strict weak ordering by ensuring it tests if both s1 is a min split and s2 is a max split.
2. In JRTCamera.cpp Clang/LLVM warns that abs() defaults to the integer-only version of abs() exported by cstdlib unless you explicitly include / use the std::abs function provided by cmath. Fixed by ensuring it uses std::abs.
3. in JRTPPMImage.cpp Clang/LLVM warns about ambiguous (or possibly invalid) order precedence while parsing a file. I added parens to enforce coalescing the or error flags to the right of the and operator.

If there are any issues please let me know :-) Thanks for releasing this!
