### PR TITLE
Migrated all projects to Unicode character set

### DIFF
--- a/Build/VS2012/TootleLib.vcxproj
+++ b/Build/VS2012/TootleLib.vcxproj
@@ -59,7 +59,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v110</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_DLL'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Build/VS2012/TootleLibSoftware.vcxproj
+++ b/Build/VS2012/TootleLibSoftware.vcxproj
@@ -59,7 +59,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v110</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_DLL'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Build/VS2012/TootleSample.vcxproj
+++ b/Build/VS2012/TootleSample.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v110</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/VS2012/TootleSampleSoftware.vcxproj
+++ b/Build/VS2012/TootleSampleSoftware.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v110</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/VS2013/TootleLib.vcxproj
+++ b/Build/VS2013/TootleLib.vcxproj
@@ -59,7 +59,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_DLL'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Build/VS2013/TootleLibSoftware.vcxproj
+++ b/Build/VS2013/TootleLibSoftware.vcxproj
@@ -59,7 +59,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_DLL'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Build/VS2013/TootleSample.vcxproj
+++ b/Build/VS2013/TootleSample.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/VS2013/TootleSampleSoftware.vcxproj
+++ b/Build/VS2013/TootleSampleSoftware.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/VS2015 - DX11_1/TootleLib.vcxproj
+++ b/Build/VS2015 - DX11_1/TootleLib.vcxproj
@@ -27,7 +27,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_Static_MTDLL'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/Build/VS2015 - DX11_1/TootleSample_DX11_1.vcxproj
+++ b/Build/VS2015 - DX11_1/TootleSample_DX11_1.vcxproj
@@ -28,7 +28,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/VS2015/TootleLib.vcxproj
+++ b/Build/VS2015/TootleLib.vcxproj
@@ -59,7 +59,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_DLL'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Build/VS2015/TootleLibSoftware.vcxproj
+++ b/Build/VS2015/TootleLibSoftware.vcxproj
@@ -59,7 +59,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_DLL'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Build/VS2015/TootleSample.vcxproj
+++ b/Build/VS2015/TootleSample.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/VS2015/TootleSampleSoftware.vcxproj
+++ b/Build/VS2015/TootleSampleSoftware.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/src/TootleLib/d3dwm.cpp
+++ b/src/TootleLib/d3dwm.cpp
@@ -52,7 +52,7 @@ HWND D3DWMCreateWindow(const char* name, D3DWindow* window)
 
 #ifdef CREATE_WINDOW
     HWND hWnd = CreateWindowEx(0,
-                               "static",
+                               TEXT("static"),
                                NULL, 0x0,
                                CW_USEDEFAULT, CW_USEDEFAULT, 0, 0, NULL, NULL, GetModuleHandle(NULL), NULL);
 #else

--- a/src/TootleLib/gdiwm.cpp
+++ b/src/TootleLib/gdiwm.cpp
@@ -44,18 +44,18 @@ int GDIWMOpen(void)
     GDIWMClass.hCursor = LoadCursor(NULL, IDC_ARROW);
     GDIWMClass.hbrBackground = NULL;
     GDIWMClass.lpszMenuName = NULL;
-    GDIWMClass.lpszClassName = "GDIWMClass";
+    GDIWMClass.lpszClassName = TEXT("GDIWMClass");
     GDIWMClass.hIconSm = NULL;
     RegisterClassEx(&GDIWMClass);
     return 1;
 }
 
-HWND GDIWMCreateWindow(const char* name, GDIWindow* window)
+HWND GDIWMCreateWindow(const TCHAR* name, GDIWindow* window)
 {
     RECT r = {0, 0, width, height};
     AdjustWindowRect(&r, WS_OVERLAPPEDWINDOW, false);
     // Create the application's window
-    HWND hWnd = CreateWindow("GDIWMClass", name,
+    HWND hWnd = CreateWindow(TEXT("GDIWMClass"), name,
                              WS_OVERLAPPEDWINDOW,
                              CW_USEDEFAULT, CW_USEDEFAULT,
                              r.right - r.left, r.bottom - r.top,
@@ -99,7 +99,7 @@ int GDIWMDestroyWindow(GDIWindow* window)
 
 int GDIWMClose(void)
 {
-    UnregisterClass("GDIWMClass", GDIWMClass.hInstance);
+    UnregisterClass(TEXT("GDIWMClass"), GDIWMClass.hInstance);
     return 0;
 }
 

--- a/src/TootleLib/gdiwm.h
+++ b/src/TootleLib/gdiwm.h
@@ -29,7 +29,7 @@ int GDIWMClose(void);
 * Creates and shows new window with title "pszName" and whose controlling
 * object instance is given by the pointer "window".
 \* -------------------------------------------------------------------------*/
-HWND GDIWMCreateWindow(const char* pszName, GDIWindow* window);
+HWND GDIWMCreateWindow(const TCHAR* pszName, GDIWindow* window);
 
 /* -------------------------------------------------------------------------*\
 * Destroy window controled by the object instance pointer "window".


### PR DESCRIPTION
This PR migrates all projects in the repository to use Unicode character set, as it should be a default in Windows nowadays (pretty much since Win9x died).

Code changes are nearly cosmetic - majority of the code is character set agnostic already, fixed instances are the ones which assumed Multi-Byte character set. With proposed changes, they are charset agnostic as well.

Proposed changes may be beneficial for those willing to integrate the code in their software - I myself encountered those issues when trying to integrate Tootle files into a project using Unicode charset. While I know the proper way is to link software against either a static or a dynamic library, this may still seem like a welcome change.

VS2012, VS2013, VS2015 and VS2015_DX11 projects have all been changed, and all verified as compiling fine.